### PR TITLE
Fix project name

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -51,7 +51,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = 'Eärendil'
+project = 'Earendil'
 copyright = '2016, Liam Bucci'
 author = 'Liam Bucci'
 


### PR DESCRIPTION
- Remove non-ascii characters from Sphinx project name.
